### PR TITLE
List number of guilds (servers) that bot is installed on.

### DIFF
--- a/DegeneSix.py
+++ b/DegeneSix.py
@@ -72,6 +72,7 @@ async def degenesix(context,actionNumber:int,difficulty=0):
     pass_context=False)
 async def degenesix(context):
     msg = "Code available at: https://github.com/MrMstislav/DiscordDegeneSix/\n"
+    msg += "Currently running on " + str(len(list(bot.guilds))) + " Discord guilds.\n"
     await context.send(msg)
     
 # @bot.event


### PR DESCRIPTION

@MrMstislav Another pull request for you to review when/if you have time. :grin:
Not sure if you want to include this option, but it is kind of nice to know how many servers are running your bot (i.e., they've invited your Amazon bot into their Discord server).
It adds this information to the DevInfo output:
<img width="487" alt="bot_guilds" src="https://user-images.githubusercontent.com/55331002/83366019-7cdc7780-a400-11ea-9b6f-2f3d49476a48.png">