### PR TITLE
fix botch condition on roll without difficulty

### DIFF
--- a/DegeneSix.py
+++ b/DegeneSix.py
@@ -219,7 +219,7 @@ def check(action_number: int, difficulty=0, auto_triggers=0):
     successes = countSuccesses(dice_roll).item() + autos
     triggers = countTriggers(dice_roll).item() + auto_triggers
 
-    is_success = successes >= difficulty
+    is_success = successes >= difficulty if difficulty > 0 else False
     is_not_botch = True if is_success else ones <= successes
 
     return {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 KatharSys die pool roller bot.
 
 ### `.env` file
-Create a `.env` file in the root of the project, this allows you to change the prefix of the box and contains the token from Discord
+Create a `.env` file in the root of the project, this allows you to change the prefix of the bot and contains the token from Discord
 ````.env
 DISCORD_BOT_PREFIX=!,?
 DISCORD_TOKEN=AAAAAAAAAAA.11111111111111111111


### PR DESCRIPTION
So basically, you cannot have a 'success' when rolling without difficulty. Let's make it so that if you roll a 1 when doing a base check, you'll eat your nice botches.

Also, Desco had a typo on the readme and he asked me to fix it xD.